### PR TITLE
Fix empty body issue in CompoundCalculator

### DIFF
--- a/CompoundCalc/Functions/CompoundCalculator.cs
+++ b/CompoundCalc/Functions/CompoundCalculator.cs
@@ -13,11 +13,11 @@ public class CompoundCalculator(ILogger<CompoundCalculator> logger, CalculationS
 {
     [Function(nameof(CompoundCalculator))]
     public async Task<IActionResult> RunAsync([HttpTrigger(AuthorizationLevel.Anonymous,
-        "get")] HttpRequest req)
+        "post")] HttpRequest req)
     {
         var reqBody = await new StreamReader(req.Body).ReadToEndAsync();
 
-        if (reqBody is null)
+        if (string.IsNullOrWhiteSpace(reqBody))
         {
             logger.LogError("Incoming request body cannot be null");
 


### PR DESCRIPTION
## Summary
- allow POST requests for the Azure Function
- treat empty bodies as invalid

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885845ae028832bac6ed7446c506468