### PR TITLE
Fix IndexedDB default categories seeding and mobile header layout

### DIFF
--- a/src/web/src/ExpenseTrackerPage.tsx
+++ b/src/web/src/ExpenseTrackerPage.tsx
@@ -863,8 +863,8 @@ export default function ExpenseTrackerPage() {
         </header>
 
         <section className="rounded-2xl bg-slate-900 p-5">
-          <div className="mb-4 flex items-center justify-between">
-            <div className="flex items-center gap-3">
+          <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-wrap items-center gap-3">
               <button className="rounded border border-slate-700 px-3 py-1" onClick={() => changeMonth(-1)}>
                 Prev
               </button>
@@ -873,7 +873,7 @@ export default function ExpenseTrackerPage() {
                 Next
               </button>
             </div>
-            <div className="flex items-center gap-2">
+            <div className="grid w-full grid-cols-1 gap-2 sm:w-auto sm:grid-cols-2">
               <button className="rounded border border-slate-700 px-4 py-2 text-sm" onClick={handleDuplicateLastExpense} disabled={!latestExpense}>
                 Duplicate last
               </button>

--- a/src/web/src/expenseTracker.ts
+++ b/src/web/src/expenseTracker.ts
@@ -214,7 +214,7 @@ export const addSubcategory = async (name: string): Promise<Subcategory> =>
   });
 
 export const seedDefaultCategories = async (): Promise<void> => {
-  await runTransaction(['categories'], 'readwrite', async tx => {
+  await runTransaction(['categories', 'subcategories'], 'readwrite', async tx => {
     const store = tx.objectStore('categories');
     const existing = await requestAsPromise(store.getAll());
 


### PR DESCRIPTION
### Motivation
- The expense tracker was failing to load default categories because `seedDefaultCategories` opened a transaction for only the `categories` store but read `subcategories` from the same transaction, which can cause IndexedDB errors. 
- The month/action header overflowed on small viewports causing buttons to clip and create poor spacing on mobile devices.

### Description
- Updated `seedDefaultCategories` to open a transaction that includes both `categories` and `subcategories` so subcategory reads occur inside the same transaction (`src/web/src/expenseTracker.ts`).
- Made the header layout responsive by stacking and wrapping the month controls and switching the action buttons to a full-width grid on small screens to prevent horizontal overflow (`src/web/src/ExpenseTrackerPage.tsx`).

### Testing
- Ran a production build with `pnpm --dir src/web build` which completed successfully.
- Launched a preview with `pnpm --dir src/web preview` and captured a mobile viewport screenshot via an automated Playwright script to visually validate the responsive header, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a89dbff724832ba1bd7725b2c0ec2d)