### PR TITLE
Docs: broaden README to financial planning scope and add agent-docs guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,38 @@
 # Compound Interest Calculator
 
-This project turns a legacy Azure Function into a full ASP.NET Core web experience for calculating
-compound interest. The API guarantees deterministic decimal math, surfaces detailed metadata for
-traceability, and ships with a lightweight React UI so people can experiment with cadences, interest
-rates, and time horizons without writing code.
+This project turns a legacy Azure Function into a full ASP.NET Core experience for financial planning
+workflows. It provides deterministic calculation APIs and a lightweight React UI so people can model
+future growth, estimate debt and mortgage scenarios, and track day-to-day budget activity in one place.
 
 ## What It Does
 
+### API calculators
+
 - `POST /api/v1/growth/contribution` projects balances for accounts that receive recurring monthly
-  deposits (think 401(k) or brokerage auto-investing) and returns the ending balance, monthly
-  contribution echo, and correlation identifiers.
+  deposits (e.g., 401(k) or brokerage auto-investing).
 - `POST /api/v1/growth/savings` models a fixed principal that compounds according to the cadence you
-  choose (e.g., HYSA or CD) so you can see how far a static balance grows with no extra deposits.
-- FluentValidation enforces business rules (principal, rates, cadence support, request metadata) and
-  emits RFC 7807 responses that include the same trace ID seen in logs.
-- Structured telemetry logs every request with a propagated `x-correlation-id`, plus dedicated events
-  for validation failures and unexpected exceptions.
-- The bundled SPA highlights the API output, echoes trace IDs, and walks users through picking a
-  compounding schedule so the backend and frontend always stay in sync.
+  choose.
+- `POST /api/v1/debt/payoff` estimates debt payoff timing and total interest under payment scenarios.
+- `POST /api/v1/mortgage/estimate` estimates monthly payment and total interest for mortgage scenarios.
+
+### Validation and observability
+
+- FluentValidation enforces request rules and returns RFC 7807 validation responses.
+- Structured telemetry propagates trace and correlation IDs through requests, logs, and responses.
+- Health checks provide readiness coverage for hosted deployments.
+
+### Web experience
+
+- **Interest calculator**: Interactive UI for growth projections powered by the API.
+- **Budget tracker**: Monthly budget planning with category-based spending views.
+- **Debt log support**: Budget categorization patterns support tracking debt-related spending/payments
+  alongside other monthly expenses.
 
 ## Tech Highlights
 
-- .NET 8 Web API with API versioning, Swagger UI, and readiness health checks for Render deployments.
-- Deterministic decimal math lives in a separate `CompoundCalc` domain assembly that can be reused in
-  other workloads or tested in isolation.
-- React 18 + Vite + Tailwind provide the UI, while a small Node script copies the build artifacts into
-  `wwwroot` so ASP.NET Core serves the same bundle in development and production.
+- .NET 8 Web API with API versioning, Swagger UI, health checks, and structured request telemetry.
+- Deterministic decimal math in a separate `CompoundCalc` domain assembly for reuse and testability.
+- React 18 + Vite + Tailwind UI, bundled into `wwwroot` so ASP.NET Core serves a single app artifact.
 
 ## Running Locally
 
@@ -38,10 +45,15 @@ rates, and time horizons without writing code.
    pnpm --dir src/web install
    pnpm --dir src/web build
    ```
-3. Run the API (serves JSON + SPA on the standard ASP.NET ports):
+3. Run the API (serves JSON + SPA on standard ASP.NET ports):
    ```bash
    dotnet run --project api/CompoundInterestCalculator.Api/CompoundInterestCalculator.Api.csproj
    ```
 
-Call the calculator with `curl`/Postman or open `http://localhost:5032` to use the UI. Execute
-`dotnet test` any time you want to run the integration and unit suites that validate the API contract.
+Call the API with `curl`/Postman or open `http://localhost:5032` to use the UI.
+
+Run tests:
+
+```bash
+dotnet test
+```

--- a/docs/agent-docs/README.md
+++ b/docs/agent-docs/README.md
@@ -1,0 +1,30 @@
+# Agent Docs (High-Level Context)
+
+This folder captures stable, high-level project context for coding agents.
+
+## Goals
+- Reduce prompt size by centralizing reusable context.
+- Keep guidance durable so docs rarely need updates.
+- Avoid implementation-level details that drift quickly.
+
+## Suggested Usage in Prompts
+- Link to these docs first.
+- Add only task-specific requirements in the prompt.
+- Avoid repeating project background unless needed.
+
+### Do I have to ask for these docs explicitly every time?
+No. You can set this as your **default prompt convention** and only override it when a task needs extra context.
+
+Recommended one-liner to reuse:
+
+`Use docs/agent-docs as baseline context; only ask follow-ups if details are missing.`
+
+## Document Index
+- `product-and-scope.md`: what the system does and does not do.
+- `architecture-principles.md`: high-level design constraints and priorities.
+- `api-contract-guidelines.md`: contract and behavior expectations without endpoint-by-endpoint implementation detail.
+- `prompt-template.md`: compact prompt scaffold for feature/fix tasks.
+- `git-operations.md`: default branch + commit workflow conventions.
+
+## Maintenance Rule
+Prefer updating these docs only when project direction or non-functional constraints change.

--- a/docs/agent-docs/api-contract-guidelines.md
+++ b/docs/agent-docs/api-contract-guidelines.md
@@ -1,0 +1,20 @@
+# API Contract Guidelines
+
+## Contract Expectations
+- Treat request/response DTOs as public contracts.
+- Prefer explicit fields and clear units/semantics.
+- Ensure validation rules are predictable and explainable.
+
+## Compatibility Approach
+- Default to non-breaking evolution.
+- If a breaking change is unavoidable, document impact and migration path.
+
+## Error and Validation Philosophy
+- Return structured, actionable validation feedback.
+- Keep error semantics consistent across endpoints.
+- Avoid ambiguous behavior for edge-case input.
+
+## Numeric Behavior
+- Prioritize deterministic decimal calculations.
+- Be explicit about rounding strategy at boundaries.
+- Ensure tests cover representative financial edge cases.

--- a/docs/agent-docs/architecture-principles.md
+++ b/docs/agent-docs/architecture-principles.md
@@ -1,0 +1,22 @@
+# Architecture Principles
+
+## System Shape
+- API-first service with stateless request processing.
+- Separation of concerns between transport, validation, mapping, and calculation logic.
+
+## Design Priorities
+1. Correctness and deterministic calculations.
+2. Contract consistency and explicit validation behavior.
+3. Operational readiness (health checks, telemetry, deploy compatibility).
+4. Readability and maintainability over cleverness.
+
+## Change Guidance
+- Favor additive, backward-compatible changes to request/response contracts.
+- Keep business math isolated from HTTP/controller concerns.
+- Use structured logging and correlation-friendly telemetry patterns.
+- Preserve consistent naming and response semantics across endpoints.
+
+## Anti-Goals
+- Embedding transport concerns deep in domain logic.
+- Introducing hidden state or non-deterministic calculation paths.
+- Expanding scope into persistence unless explicitly required.

--- a/docs/agent-docs/git-operations.md
+++ b/docs/agent-docs/git-operations.md
@@ -1,0 +1,62 @@
+# Git Operations Guide
+
+Use this as the default workflow for repository hygiene and predictable history.
+
+## Default Branching Workflow
+
+1. Start from the local `main` branch.
+2. Sync it with the remote using rebase:
+
+   ```bash
+   git checkout main
+   git pull --rebase origin main
+   ```
+
+3. Create a new topic branch from updated `main`:
+
+   ```bash
+   git checkout -b <type>/<short-description>
+   ```
+
+## Commit Message Standard
+
+All commits should use **Conventional Commit** format for the subject line:
+
+```text
+<type>(optional-scope): <short summary>
+```
+
+Every commit should also include a brief body (1-3 bullets or short lines) describing
+what changed and why. Keep it concise, but specific enough that someone can understand
+the intent without opening the diff immediately.
+
+Suggested `git commit` usage:
+
+```bash
+git commit -m "feat(api): add debt payoff totals" \
+  -m "- include total interest + payoff month in response
+- keep contract backward compatible"
+```
+
+Examples:
+
+- `feat(api): add debt payoff scenario metadata`
+- `fix(web): correct budget total rounding`
+- `docs(agent-docs): add git operations defaults`
+- `test(api): cover mortgage validation edge cases`
+
+## Recommended Types
+
+- `feat`: new functionality
+- `fix`: bug fix
+- `docs`: documentation-only updates
+- `refactor`: code restructuring without behavior change
+- `test`: tests added/updated
+- `chore`: tooling, dependency, or maintenance changes
+
+## Practical Rules
+
+- Keep commits focused and scoped to a single intent.
+- Include a concise commit body for context, not just a one-line subject.
+- Prefer multiple small conventional commits over one mixed commit.
+- Rebase your feature branch on `main` before opening or updating a PR when needed.

--- a/docs/agent-docs/product-and-scope.md
+++ b/docs/agent-docs/product-and-scope.md
@@ -1,0 +1,24 @@
+# Product and Scope
+
+## Purpose
+Provide deterministic financial calculation APIs for growth, debt payoff, and mortgage estimation scenarios.
+
+## Core Outcomes
+- Reliable calculation responses for client applications.
+- Predictable request validation and error behavior.
+- Operational visibility through health and telemetry signals.
+
+## In Scope (High Level)
+- Stateless calculation endpoints.
+- Request validation and structured API responses.
+- API observability and deployability.
+
+## Out of Scope (High Level)
+- User accounts and authentication workflows.
+- Persistent user data storage.
+- Workflow orchestration beyond single request/response operations.
+
+## Stability Priorities
+- Deterministic numeric behavior.
+- Backward compatibility mindset for public contracts.
+- Clear operational defaults for hosted deployment.

--- a/docs/agent-docs/prompt-template.md
+++ b/docs/agent-docs/prompt-template.md
@@ -1,0 +1,34 @@
+# Prompt Template (Compact)
+
+Use this template to keep prompts short while still providing enough context.
+
+If this context is your normal workflow, you can keep this single line as a standing default:
+
+`Use docs/agent-docs as baseline context and proceed unless critical details are missing.`
+
+```text
+Task:
+- <feature/fix/refactor objective>
+
+Use project context from:
+- docs/agent-docs/product-and-scope.md
+- docs/agent-docs/architecture-principles.md
+- docs/agent-docs/api-contract-guidelines.md
+- docs/agent-docs/git-operations.md
+
+Constraints:
+- Keep changes backward compatible unless noted.
+- Keep implementation aligned with deterministic financial calculations.
+- Add/update tests for behavior changes.
+- Use Conventional Commits for all commit messages.
+
+Deliverables:
+- Code changes
+- Tests
+- Brief summary of contract/behavior impacts
+```
+
+## Optional Task-Specific Additions
+- Acceptance criteria bullets
+- Explicit non-goals
+- Performance or observability notes


### PR DESCRIPTION
### Motivation

- Update the project README to reflect a broader financial planning focus that includes growth, debt, mortgage, and budgeting scenarios instead of only a compound interest calculator.
- Surface additional API endpoints, validation, observability, and web experience features so README aligns with the current public surface.
- Add a durable, centralized `docs/agent-docs` collection to provide high-level context and prompt templates for coding agents and to reduce prompt duplication.

### Description

- Rewrote `README.md` to expand the project description, add new API calculator endpoints (`/api/v1/debt/payoff`, `/api/v1/mortgage/estimate`), and reorganize sections for validation, observability, and web experience.
- Updated tech highlights and local run instructions and added an explicit `dotnet test` example to the `README.md` test section.
- Added a new `docs/agent-docs` folder with six files: `README.md`, `api-contract-guidelines.md`, `architecture-principles.md`, `git-operations.md`, `product-and-scope.md`, and `prompt-template.md`, each providing high-level project context, contract guidance, architecture principles, git workflow recommendations, product scope, and a prompt template for agents.
- Changes are documentation-only and do not modify runtime code, APIs, or tests.

### Testing

- This is a documentation-only change, and no automated tests were modified or executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac6847c158832b9cdfb6c8765b0ac3)