### PR TITLE
center budget table alignment

### DIFF
--- a/src/web/src/ExpenseTrackerPage.tsx
+++ b/src/web/src/ExpenseTrackerPage.tsx
@@ -1244,10 +1244,10 @@ export default function ExpenseTrackerPage() {
             <div className="rounded border border-slate-800">
               <div className="hidden items-center gap-x-3 border-b border-slate-800 px-3 py-2 text-xs uppercase tracking-wide text-slate-400 sm:grid sm:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,14ch)]">
                 <div>Item</div>
-                <div className="justify-self-end text-right">Budget</div>
-                <div className="justify-self-end text-right">Spent</div>
-                <div className="justify-self-end text-right">Remaining</div>
-                <div className="justify-self-end text-right">Status</div>
+                <div className="justify-self-center text-center">Budget</div>
+                <div className="justify-self-center text-center">Spent</div>
+                <div className="justify-self-center text-center">Remaining</div>
+                <div className="justify-self-center text-center">Status</div>
               </div>
               <div className="divide-y divide-slate-800">
                 {groupedBudgetItems.map(group => {
@@ -1320,13 +1320,13 @@ export default function ExpenseTrackerPage() {
                               onDragEnd={handleBudgetDragEnd}
                             >
                               <div className="order-1 font-medium sm:order-none">{category.name}</div>
-                              <div className="order-4 justify-self-stretch sm:order-none">
+                              <div className="order-4 justify-self-stretch sm:order-none sm:w-full sm:max-w-[12rem] sm:justify-self-center">
                                 <input
                                   type="number"
                                   min="0"
                                   step="0.01"
                                   inputMode="decimal"
-                                  className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1 text-right text-sm tabular-nums"
+                                  className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1 text-center text-sm tabular-nums"
                                   value={budgetInputs[category.id] ?? ''}
                                   onChange={e => setBudgetInputs(prev => ({ ...prev, [category.id]: e.target.value }))}
                                   onBlur={() => void handleBudgetAutoSave(category.id)}
@@ -1339,16 +1339,16 @@ export default function ExpenseTrackerPage() {
                                   aria-label={`Budget for ${category.name}`}
                                 />
                               </div>
-                              <div className="order-3 justify-self-end text-right tabular-nums text-slate-300 sm:order-none">{formatCurrency(spent)}</div>
+                              <div className="order-3 justify-self-end text-right tabular-nums text-slate-300 sm:order-none sm:justify-self-center sm:text-center">{formatCurrency(spent)}</div>
                               <div
-                                className={`order-2 justify-self-end text-right font-semibold tabular-nums sm:order-none ${
+                                className={`order-2 justify-self-end text-right font-semibold tabular-nums sm:order-none sm:justify-self-center sm:text-center ${
                                   delta >= 0 ? 'text-emerald-300' : 'text-rose-300'
                                 }`}
                               >
                                 {formatCurrency(delta)}
                               </div>
                               <div
-                                className={`order-5 col-span-2 justify-self-end text-right text-xs sm:col-span-1 sm:order-none ${
+                                className={`order-5 col-span-2 justify-self-end text-right text-xs sm:col-span-1 sm:order-none sm:justify-self-center sm:text-center ${
                                   status === 'error' ? 'text-rose-300' : status === 'saved' ? 'text-emerald-300' : 'text-slate-400'
                                 }`}
                               >
@@ -1360,16 +1360,16 @@ export default function ExpenseTrackerPage() {
                       ))}
                       <div className="grid grid-cols-2 gap-x-3 gap-y-1 bg-slate-950/60 px-3 py-2 text-xs sm:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,14ch)]">
                         <div className="order-1 font-semibold text-slate-300 sm:order-none">Subtotal</div>
-                        <div className="order-4 justify-self-end text-right font-semibold tabular-nums text-slate-300 sm:order-none">
+                        <div className="order-4 justify-self-end text-right font-semibold tabular-nums text-slate-300 sm:order-none sm:justify-self-center sm:text-center">
                           {formatCurrency(group.totals.budget)}
                         </div>
-                        <div className="order-3 justify-self-end text-right font-semibold tabular-nums text-slate-300 sm:order-none">
+                        <div className="order-3 justify-self-end text-right font-semibold tabular-nums text-slate-300 sm:order-none sm:justify-self-center sm:text-center">
                           {formatCurrency(group.totals.spent)}
                         </div>
-                        <div className="order-2 justify-self-end text-right font-semibold tabular-nums text-slate-300 sm:order-none">
+                        <div className="order-2 justify-self-end text-right font-semibold tabular-nums text-slate-300 sm:order-none sm:justify-self-center sm:text-center">
                           {formatCurrency(group.totals.remaining)}
                         </div>
-                        <div className="order-5 col-span-2 justify-self-end text-right text-xs text-slate-500 sm:col-span-1 sm:order-none">
+                        <div className="order-5 col-span-2 justify-self-end text-right text-xs text-slate-500 sm:col-span-1 sm:order-none sm:justify-self-center sm:text-center">
                           {group.name}
                         </div>
                       </div>
@@ -1378,14 +1378,14 @@ export default function ExpenseTrackerPage() {
                 })}
                 <div className="grid grid-cols-2 gap-x-3 gap-y-1 bg-slate-950/40 px-3 py-2 text-sm sm:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,14ch)]">
                   <div className="order-1 font-semibold text-slate-200 sm:order-none">Total</div>
-                  <div className="order-4 justify-self-end text-right font-semibold tabular-nums text-slate-200 sm:order-none">
+                  <div className="order-4 justify-self-end text-right font-semibold tabular-nums text-slate-200 sm:order-none sm:justify-self-center sm:text-center">
                     {formatCurrency(budgetTotals.budget)}
                   </div>
-                  <div className="order-3 justify-self-end text-right font-semibold tabular-nums text-slate-200 sm:order-none">
+                  <div className="order-3 justify-self-end text-right font-semibold tabular-nums text-slate-200 sm:order-none sm:justify-self-center sm:text-center">
                     {formatCurrency(budgetTotals.spent)}
                   </div>
-                  <div className="order-2 justify-self-end text-right text-slate-500 sm:order-none">—</div>
-                  <div className="order-5 col-span-2 justify-self-end text-right text-xs text-slate-500 sm:col-span-1 sm:order-none">Totals</div>
+                  <div className="order-2 justify-self-end text-right text-slate-500 sm:order-none sm:justify-self-center sm:text-center">—</div>
+                  <div className="order-5 col-span-2 justify-self-end text-right text-xs text-slate-500 sm:col-span-1 sm:order-none sm:justify-self-center sm:text-center">Totals</div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## What changed
Aligned the desktop budget items table so the `Budget`, `Spent`, `Remaining`, and `Status` headers center with their corresponding row values.

Updated the budget input column to center the input field and its value, and matched the subtotal and total rows to that same column alignment.

## Why it changed
The budget table mixed right-aligned and centered cells in the desktop grid, which made the header, entered amounts, and subtotal values feel visually off-axis.

## Impact
The budget items section now reads more cleanly on desktop, with the budget column and summary rows lining up consistently.

## Root cause
The table header and summary cells were using `justify-self-end text-right` while the column content needed centered placement to match the visual structure of the budget inputs.

## Validation
- `npm run build`
- Verified the desktop layout locally at `http://127.0.0.1:5173/` on the Budget tracker page